### PR TITLE
Fix issue by mail-lookup via IMAP search

### DIFF
--- a/lib/mail.py
+++ b/lib/mail.py
@@ -45,6 +45,7 @@ def waitformail(token, server, port, user=None, password=None, ssl=False, debug=
 		if waited_seconds > 120:
 			raise Exception("Timeout waiting for mail to arrive")
 
+		mail.select("inbox")
 		result, data = mail.uid('search', None, '(HEADER Subject "' + token + '")')
 
 	uid = data[0]


### PR DESCRIPTION
Somehow on IMAP search it's required to select the mailbox before run the search command. For example on GMail and other IMAP servers the search command only works correctly after selecting the folder. Also some IMAP servers lost the selection after the first search command.
